### PR TITLE
fix exit code not returning correctly

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -73,16 +73,13 @@ concurently(commands, options).then(
         logSuccess('\ndone');
     },
     (errorResponse) => {
-        logError('\nOne of tasks returned error');
+        const commandWithError = errorResponse.find(
+            (closeEvent) => closeEvent.exitCode > 0
+        );
 
-        if (Array.isArray(errorResponse)) {
-            const commandWithError = errorResponse.find(
-                (closeEvent) => closeEvent.exitCode > 0
-            );
+        logError('\nOne of tasks returned error:');
+        logDebug(commandWithError);
 
-            process.exit(commandWithError.exitCode);
-        } else {
-            process.exit(errorResponse.exitCode);
-        }
+        process.exit(commandWithError.exitCode);
     }
 );

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,17 +72,17 @@ concurently(commands, options).then(
     () => {
         logSuccess('\ndone');
     },
-    (failureExitCode) => {
+    (errorResponse) => {
         logError('\nOne of tasks returned error');
 
-        if (Array.isArray(failureExitCode)) {
-            const containsErrorExitCode = failureExitCode.some(
-                (code) => parseInt(code) > 0
+        if (Array.isArray(errorResponse)) {
+            const commandWithError = errorResponse.find(
+                (closeEvent) => closeEvent.exitCode > 0
             );
 
-            process.exit(containsErrorExitCode ? 1 : 0);
+            process.exit(commandWithError.exitCode);
         } else {
-            process.exit(failureExitCode);
+            process.exit(errorResponse.exitCode);
         }
     }
 );


### PR DESCRIPTION
Lijkt er op dat de response veranderd is, in de documentatie staat nu ook dat het een object is inplaats van direct de exitCode.

Dit is bv een response wanner er een taak faalt:

```
[
  {
    command: {
      command: 'cd ./assets/campingMapEditor && npm run dev:build',
      name: 'campingMapEditor',
      prefixColor: 'cyan.bold',
      env: {}
    },
    index: 2,
    exitCode: 1,
    killed: false
  },
  {
    command: {
      command: 'cd ./assets/admin && npm run dev:build',
      name: 'admin',
      prefixColor: 'yellow.bold',
      env: {}
    },
    index: 0,
    exitCode: 'SIGTERM',
    killed: true
  },
  {
    command: {
      command: 'cd ./assets/frontend && npm run dev:build',
      name: 'frontend',
      prefixColor: 'blue.bold',
      env: {}
    },
    index: 1,
    exitCode: 'SIGTERM',
    killed: true
  }
]

```

Ik heb het zo aanpast dat hij de exitCode uit het object teruggeeft. Eerst werd er in het geval van een array ook altijd 1 of 0 teruggeven.