### PR TITLE
Allow higher node versions than 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "prettier": "prettier --write 'src/**/*.{js,json,md}'"
     },
     "engines": {
-        "node": "^16.0.0"
+        "node": ">=16"
     },
     "bin": {
         "run-concurrently": "./src/cli.js"


### PR DESCRIPTION
Otherwise when you use node 18 it will still throw a warning that the node version is incorrect.